### PR TITLE
added sqlparse dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 import ipydb
 
-requires = ['SQLAlchemy', 'ipython>=0.11', 'python-dateutil']
+requires = ['SQLAlchemy', 'ipython>=0.11', 'python-dateutil', 'sqlparse']
 description = "An IPython extension to help you write and run SQL statements"
 
 setup(


### PR DESCRIPTION
`%load_ext ipydb` fails if sqlparse is not installed.
