### PR TITLE
remove deprecated package warnings in IPython 4

### DIFF
--- a/ipydb/metadata/__init__.py
+++ b/ipydb/metadata/__init__.py
@@ -21,7 +21,11 @@ import os
 import sqlalchemy as sa
 from sqlalchemy import orm
 from sqlalchemy.engine.url import URL
-from IPython.utils.path import locate_profile
+try:
+    from IPython.paths import locate_profile
+except ImportError:
+    # IPython 3 support
+    from IPython.utils.path import locate_profile
 
 from ipydb.utils import timer
 from . import model as m

--- a/ipydb/plugin.py
+++ b/ipydb/plugin.py
@@ -16,8 +16,12 @@ import shlex
 import subprocess
 import sys
 
+try:
+    from traitlets.config.configurable import Configurable
+except ImportError:
+    # IPython 3 support
+    from IPython.config.configurable import Configurable
 
-from IPython.config.configurable import Configurable
 from future.utils import viewvalues
 import sqlalchemy as sa
 


### PR DESCRIPTION
Running ipydb in IPython 4 you get warnings like when loading ipydb:

    /.../IPython/config.py:13: ShimWarning: The `IPython.config` package has been deprecated. You should import from traitlets.config instead.
      "You should import from traitlets.config instead.", ShimWarning)

this when running ipdb queries:

    /.../IPython/utils/path.py:282: UserWarning: locate_profile has moved to the IPython.paths module
      warn("locate_profile has moved to the IPython.paths module")

This pull request (try/except import hax :/) removes those warnings in [IPython 4 due to deprecated packages](http://ipython.readthedocs.org/en/stable/whatsnew/version4.html) whilst falling back to the IPython 3 imports.  If you want to support IPython 4 as the minumum, you can just use the new imports (and forget the `except` imports).  If the warning messages don't bother you, ignore this pull request :).
